### PR TITLE
Fix build on Linux.

### DIFF
--- a/libtiff/CMakeLists.txt
+++ b/libtiff/CMakeLists.txt
@@ -4,6 +4,7 @@
 # ----------------------------------------------------------------------------
 include(CheckFunctionExists)
 include(CheckIncludeFile)
+include(CheckLibraryExists)
 include(TestBigEndian)
 
 check_include_file(assert.h HAVE_ASSERT_H)
@@ -98,6 +99,12 @@ endif()
 
 add_library(libtiff ${lib_srcs})
 target_link_libraries(libtiff PUBLIC ZLIB::zlib)
+
+# Some platforms (e.g. Linux) need separate math library
+check_library_exists(m pow "" LIB_M_REQUIRED)
+if(LIB_M_REQUIRED)
+  target_link_libraries(libtiff PRIVATE m)
+endif()
 
 if(UNIX AND CMAKE_COMPILER_IS_GNUCXX)
   set_target_properties(libtiff PROPERTIES POSITION_INDEPENDENT_CODE TRUE)


### PR DESCRIPTION
Math functions (pow, floor, etc.) require a separate math library on Linux (probably some other platforms too.  That wasn't being linked so the final linkage didn't work on Linux when library was used as part of an exe or built as a shared lib.

This change adds a platform check for a math function in the math library and links it if found.  CMake usage requirements should take care of linking it into the final binary.
